### PR TITLE
Docker image optimizations

### DIFF
--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -5,8 +5,6 @@ USER root
 COPY . /project
 RUN cd /project && ./mvnw clean package
 
-USER 1000
-
 FROM jboss/keycloak:10.0.1
 USER root
 COPY --from=0 /project/target/*.jar /opt/jboss/keycloak/standalone/deployments/app.jar

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak
+FROM jboss/keycloak:10.0.1
 
 ARG JAR_FILE=target/*.jar
 

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -1,10 +1,13 @@
 FROM jboss/keycloak:10.0.1
 
-ARG JAR_FILE=target/*.jar
-
 USER root
 
 COPY . /project
-RUN cd /project && ./mvnw clean package && mv ${JAR_FILE} /opt/jboss/keycloak/standalone/deployments/app.jar
+RUN cd /project && ./mvnw clean package
 
+USER 1000
+
+FROM jboss/keycloak:10.0.1
+USER root
+COPY --from=0 /project/target/*.jar /opt/jboss/keycloak/standalone/deployments/app.jar
 USER 1000


### PR DESCRIPTION
This copies the built jar file into a new image so that the final image doesn't contain the build dependencies. Makes for a smaller docker image.
This also specifies the tag to use so that builds are more predictable. 