### PR TITLE
Consistently remove federation link

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -95,7 +95,8 @@ public class LegacyProvider implements UserStorageProvider,
 
     @Override
     public boolean updateCredential(RealmModel realm, UserModel user, CredentialInput input) {
-        if (!user.getFederationLink().isBlank()) {
+        String link = user.getFederationLink();
+        if (link != null && !link.isBlank()) {
             user.setFederationLink(null);
         }
         return false;

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -5,6 +5,7 @@ import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUserService;
 import com.danielfrak.code.keycloak.providers.rest.remote.UserModelFactory;
 import org.jboss.logging.Logger;
 import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialInputUpdater;
 import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -21,7 +22,10 @@ import java.util.function.Supplier;
 /**
  * Provides legacy user migration functionality
  */
-public class LegacyProvider implements UserStorageProvider, UserLookupProvider, CredentialInputValidator {
+public class LegacyProvider implements UserStorageProvider,
+        UserLookupProvider,
+        CredentialInputUpdater,
+        CredentialInputValidator {
 
     private static final Logger LOG = Logger.getLogger(LegacyProvider.class);
     private static final Set<String> supportedCredentialTypes = Collections.singleton(PasswordCredentialModel.TYPE);
@@ -63,7 +67,6 @@ public class LegacyProvider implements UserStorageProvider, UserLookupProvider, 
 
         if (legacyUserService.isPasswordValid(userModel.getUsername(), input.getChallengeResponse())) {
             session.userCredentialManager().updateCredential(realmModel, userModel, input);
-            userModel.setFederationLink(null);
             return true;
         }
 
@@ -89,4 +92,23 @@ public class LegacyProvider implements UserStorageProvider, UserLookupProvider, 
     public void close() {
         // Not needed
     }
+
+    @Override
+    public boolean updateCredential(RealmModel realm, UserModel user, CredentialInput input) {
+        if (!user.getFederationLink().isBlank()) {
+            user.setFederationLink(null);
+        }
+        return false;
+    }
+
+    @Override
+    public void disableCredentialType(RealmModel realm, UserModel user, String credentialType) {
+        // Not needed
+    }
+
+    @Override
+    public Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
+        return Collections.emptySet();
+    }
+
 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -146,5 +148,41 @@ class LegacyProviderTest {
     void getUserByIdShouldThrowException() {
         var realm = mock(RealmModel.class);
         assertThrows(UnsupportedOperationException.class, () -> legacyProvider.getUserById("someId", realm));
+    }
+
+    @Test
+    void removeFederationLinkWhenCredentialUpdates() {
+        var input = mock(CredentialInput.class);
+        when(userModel.getFederationLink())
+                .thenReturn("someId");
+
+        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
+
+        verify(userModel)
+                .setFederationLink(null);
+    }
+
+    @Test
+    void doNotRemoveFederationLinkWhenBlankAndCredentialUpdates() {
+        var input = mock(CredentialInput.class);
+        when(userModel.getFederationLink())
+                .thenReturn(" ");
+
+        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
+
+        verify(userModel, never())
+                .setFederationLink(null);
+    }
+
+    @Test
+    void doNotRemoveFederationLinkWhenNullAndCredentialUpdates() {
+        var input = mock(CredentialInput.class);
+        when(userModel.getFederationLink())
+                .thenReturn(null);
+
+        assertFalse(legacyProvider.updateCredential(realmModel, userModel, input));
+
+        verify(userModel, never())
+                .setFederationLink(null);
     }
 }


### PR DESCRIPTION
Previously when a user successfully authenticated through the
legacy provider REST API, the Keycloak user would have the federation
link removed.

However, when the user account received a credential through any other
mechanism (forgot password flow, set in Keycloak UI by a user with
manage user permission, etc) the federation link would not be removed.

This behavior led to inconsistent production data based on the
mechanism that set the user credential. This fix moves the link removal
to the CredentialInputUpdater capability interface. Now any time the
credential is set (regardless of method) and the federation link is
present, it will be consistently removed.