### PR TITLE
Add option to use user id for credential verification request

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ https://codesoapbox.dev/keycloak-user-migration
 
 You must provide two REST endpoints (GET and POST) in your legacy authentication system under the URI `${restClientUri
 }/{$username}`, where `${restClientUri}` is a configurable base URL for the endpoints and `{$username}` is the
-username of the user that is attempting to sign in.
+username of the user that is attempting to sign in. It is possible to configure the plugin to use the legacy `userId`
+instead of the username when making the credential verification request. This option should only be enabled when the 
+legacy user ids are migrated to Keycloak.
 
 ### GET
 The GET request will have to return user data as a JSON response in the form:
@@ -71,6 +73,7 @@ If a user with the username `bob` and the password `password123` tries to log in
 The response might look like this:
 ```json
 {
+    "id": "12345678",
     "username": "bob",
     "email": "bob@company.com",
     "firstName": "Bob",
@@ -96,6 +99,9 @@ the body:
 
 As this is the correct password, the user will be logged in. In the background, his information will be migrated to
 Keycloak.
+
+If the plugin is configured to use the user id as the path parameter for the credential verification request, a `POST`
+request will be performed to `http://www.old-legacy-system.com/auth/12345678`.
 
 ## Launching and configuring the example
 1. Navigate to `./docker`

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <java.version>11</java.version>
-        <keycloak.version>11.0.0</keycloak.version>
+        <keycloak.version>12.0.0</keycloak.version>
         <resteasy.version>4.4.1.Final</resteasy.version>
 
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
@@ -11,6 +11,7 @@ public final class ConfigurationProperties {
     public static final String PROVIDER_NAME = "User migration using a REST client";
     public static final String URI_PROPERTY = "URI";
     public static final String API_TOKEN_PROPERTY = "API_TOKEN";
+    public static final String USE_USER_ID_FOR_CREDENTIAL_VERIFICATION = "USE_USER_ID_FOR_CREDENTIAL_VERIFICATION";
     public static final String ROLE_MAP_PROPERTY = "ROLE_MAP";
     public static final String GROUP_MAP_PROPERTY = "GROUP_MAP";
     public static final String MIGRATE_UNMAPPED_ROLES_PROPERTY = "MIGRATE_UNMAPPED_ROLES";
@@ -23,6 +24,10 @@ public final class ConfigurationProperties {
             new ProviderConfigProperty(API_TOKEN_PROPERTY,
                     "Rest client API token", "Bearer token",
                     PASSWORD, null),
+            new ProviderConfigProperty(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION,
+                    "Use user id for credential verification",
+                    "Use the id of the user as the path parameter when making a credential verification request",
+                    BOOLEAN_TYPE, false),
             new ProviderConfigProperty(ROLE_MAP_PROPERTY,
                     "Legacy role conversion", "Role conversion in the format 'legacyRole:newRole'",
                     MULTIVALUED_STRING_TYPE, null),

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderFactory.java
@@ -22,7 +22,8 @@ public class LegacyProviderFactory implements UserStorageProviderFactory<LegacyP
     @Override
     public LegacyProvider create(KeycloakSession session, ComponentModel model) {
         var userModelFactory = new UserModelFactory(session, model);
-        return new LegacyProvider(session, new RestUserService(model, ClientBuilder.newClient()), userModelFactory);
+        var restService = new RestUserService(model, ClientBuilder.newClient());
+        return new LegacyProvider(session, restService, userModelFactory, model);
     }
 
     @Override

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -6,6 +6,8 @@ import com.danielfrak.code.keycloak.providers.rest.remote.UserModelFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.models.KeycloakSession;
@@ -16,8 +18,10 @@ import org.keycloak.models.credential.PasswordCredentialModel;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
+import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -44,9 +48,12 @@ class LegacyProviderTest {
     @Mock
     private UserModel userModel;
 
+    @Mock
+    private ComponentModel model;
+
     @BeforeEach
     void setUp() {
-        legacyProvider = new LegacyProvider(session, legacyUserService, userModelFactory);
+        legacyProvider = new LegacyProvider(session, legacyUserService, userModelFactory, model);
     }
 
     @Test
@@ -94,6 +101,10 @@ class LegacyProviderTest {
         when(input.getType())
                 .thenReturn(PasswordCredentialModel.TYPE);
 
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("false"));
+        when(model.getConfig()).thenReturn(config);
+
         final String username = "user";
         final String password = "password";
 
@@ -115,6 +126,10 @@ class LegacyProviderTest {
         when(input.getType())
                 .thenReturn(PasswordCredentialModel.TYPE);
 
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("false"));
+        when(model.getConfig()).thenReturn(config);
+
         final String username = "user";
         final String password = "password";
 
@@ -123,6 +138,34 @@ class LegacyProviderTest {
         when(input.getChallengeResponse())
                 .thenReturn(password);
         when(legacyUserService.isPasswordValid(username, password))
+                .thenReturn(true);
+
+        when(session.userCredentialManager())
+                .thenReturn(mock(UserCredentialManager.class));
+
+        var result = legacyProvider.isValid(realmModel, userModel, input);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void isValidReturnsTrueWhenUserValidatedWithUserId() {
+        var input = mock(CredentialInput.class);
+        when(input.getType())
+                .thenReturn(PasswordCredentialModel.TYPE);
+
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+        config.put(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION, List.of("true"));
+        when(model.getConfig()).thenReturn(config);
+
+        final String userId = "1234567890";
+        final String password = "password";
+
+        when(userModel.getId())
+                .thenReturn(userId);
+        when(input.getChallengeResponse())
+                .thenReturn(password);
+        when(legacyUserService.isPasswordValid(userId, password))
                 .thenReturn(true);
 
         when(session.userCredentialManager())


### PR DESCRIPTION
Until now it was possible to end up in a state where credentials couldn't be verified if the username was changed between the GET and POST requests. 

Imagine the following scenario:
- User enters their username and an invalid password
- Keycloak fetches the user from the legacy system and migrates it without the credentials
- Because the password is invalid the user federation link is not deleted
- The legacy system receives a user update requests which changes the username, and updates in keycloak because the user entity is already migrated
- User tries to login again with valid credentials
- Keycloak will find the already migrated entity and make a request to verify the credentials, but because the username has changed it will not be able to verify the credentials

@daniel-frak let me know if the implementation makes sense