### PR TITLE
Role creation on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ Authorization: Basic base64encode(username:password)
 If role names in Keycloak do not perfectly match those in the legacy system, you can configure the provider to
 automatically map legacy roles to Keycloak roles, by specifying the mapping in the format `legacyRole:keycloakRole`.
 
-Note that roles cannot be created during import, they need to exist in Keycloak first.
-
 ### Migrate unmapped roles
 
 This switch can be toggled to decide whether roles which are not defined in the legacy role conversion map should be


### PR DESCRIPTION
Follow-up to #23 

Also add a little test of this behavior.

It would be important to fix the behavior in role import.

Today, when not present, realm is searched, then clients are searched, the first client with a rule with that name grant the rule to the user.

If no client has the rule, it is created in the realm.

I suppose a configuration knob would be good to define rule creation in a specific client. Ldap federation does that today. If curious, take a look at [ldap mapping rules](https://github.com/keycloak/keycloak/blob/a41f5c390da71f3254beb666ee0ad35db31563bc/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/role/RoleLDAPStorageMapper.java#L85).

