### PR TITLE
Use correct resteasy-client dependency and import correct class, closes #33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <java.version>11</java.version>
-        <keycloak.version>15.0.0</keycloak.version>
-        <resteasy.version>4.4.1.Final</resteasy.version>
+        <keycloak.version>15.0.2</keycloak.version>
+        <resteasy.version>3.13.2.Final</resteasy.version>
         <mockito.version>3.9.0</mockito.version>
 
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -20,12 +20,23 @@
         <jacoco.version>0.8.5</jacoco.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.keycloak.bom</groupId>
+                <artifactId>keycloak-spi-bom</artifactId>
+                <version>${keycloak.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.keycloak/keycloak-core -->
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -33,7 +44,6 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -2,8 +2,8 @@ package com.danielfrak.code.keycloak.providers.rest.rest;
 
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUserService;
+import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.client.jaxrs.internal.BasicAuthentication;
 import org.keycloak.component.ComponentModel;
 
 import javax.ws.rs.client.Client;

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -1,8 +1,8 @@
 package com.danielfrak.code.keycloak.providers.rest.rest;
 
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
+import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.client.jaxrs.internal.BasicAuthentication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Previously an incompatible version of resteasy-clinet was being used. I downgraded it to a compatible version and fixed the import to BasicAuthentication. It seems the other BasicAuthetication import was an accident to begin with, as it is in a packages called "internal".