### PR TITLE
Upgrade Keycloak to 16.1.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ https://codesoapbox.dev/keycloak-user-migration
 
 | Keycloak Version | Commit                                                                                                                                           |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| 15.X             | Current                                                                                                                                          |
+| 16.1.X           | Current                                                                                                                                          |
+| 15.X             | [922c69440a776f0cab80b68b90c90a6ba620cdd9](https://github.com/daniel-frak/keycloak-user-migration/commit/922c69440a776f0cab80b68b90c90a6ba620cdd9) |
 | 12.X             | [0966d9ba7c94ba461783a5d8dda0735a35c4e6b8](https://github.com/daniel-frak/keycloak-user-migration/commit/0966d9ba7c94ba461783a5d8dda0735a35c4e6b8) |
 | 11.x             | [9f59cdf7fa888c31c5cda3d1fe014c9a0682ab30](https://github.com/daniel-frak/keycloak-user-migration/tree/9f59cdf7fa888c31c5cda3d1fe014c9a0682ab30) |
 | 9.X              | [c9c64162b91cedc29d8bf360c3df50b69fdb4c6b](https://github.com/daniel-frak/keycloak-user-migration/tree/c9c64162b91cedc29d8bf360c3df50b69fdb4c6b) |

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <properties>
         <java.version>11</java.version>
-        <keycloak.version>15.0.2</keycloak.version>
+        <keycloak.version>16.1.0</keycloak.version>
         <resteasy.version>3.13.2.Final</resteasy.version>
         <mockito.version>3.9.0</mockito.version>
 


### PR DESCRIPTION
A new version of Keycloak was released last week which fix a critical vulnerability in 12.X-15.X versions. This change updates the keycloak dependencies to 16.1.X.