### PR TITLE
multi-stage build for docker

### DIFF
--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -1,15 +1,14 @@
-ARG KEYCLOAK_IMAGE
+ARG KEYCLOAK_IMAGE=quay.io/keycloak/keycloak:19.0.1
+
+FROM maven as builder
+COPY pom.xml /tmp/
+COPY src /tmp/src
+WORKDIR /tmp/
+RUN mvn clean package
 
 FROM $KEYCLOAK_IMAGE
-
 USER root
-
-COPY . /project
-#RUN cd /project && ./mvnw clean package
-
-FROM $KEYCLOAK_IMAGE
-USER root
-COPY --from=0 /project/target/*.jar /opt/keycloak/providers/app.jar
+COPY --from=builder /tmp/target/*.jar /opt/keycloak/providers/app.jar
 USER 1000
 
 ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev" , "--features-disabled=admin2"]


### PR DESCRIPTION
Hello,

I find your project as i'm going to migrate my legacy system to keycloak and needed some easy integration for it.

Can I suggest an improvement to build the docker image ?

Instead of using maven as a commandline that only java developers may have already installed. It's possible to use a multi-stage docker build using maven within the Dockerfile and only copying the needed .jar files to Keycloak build.

I've added a default value for KEYCLOAK_IMAGE too as it should be able to run without the docker-compose file (but that's removable if you want)