### PR TITLE
URI encode username path segment

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -6,6 +6,7 @@ import com.danielfrak.code.keycloak.providers.rest.exceptions.RestUserProviderEx
 import com.danielfrak.code.keycloak.providers.rest.rest.http.HttpClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
+import org.keycloak.common.util.Encode;
 import org.keycloak.component.ComponentModel;
 
 import java.io.IOException;
@@ -68,6 +69,9 @@ public class RestUserService implements LegacyUserService {
     }
 
     private Optional<LegacyUser> findLegacyUser(String usernameOrEmail) {
+        if (usernameOrEmail != null) {
+            usernameOrEmail = Encode.urlEncode(usernameOrEmail);
+        }
         var getUsernameUri = String.format("%s/%s", this.uri, usernameOrEmail);
         try {
             var response = this.httpClient.get(getUsernameUri);
@@ -83,6 +87,9 @@ public class RestUserService implements LegacyUserService {
 
     @Override
     public boolean isPasswordValid(String username, String password) {
+        if (username != null) {
+            username = Encode.urlEncode(username);
+        }
         var passwordValidationUri = String.format("%s/%s", this.uri, username);
         var dto = new UserPasswordDto(password);
         try {

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -326,6 +326,21 @@ class RestUserServiceTest {
     }
 
     @Test
+    void isPasswordValidShouldNotThrowNullPointerExceptionWhenPasswordIsNull() throws IOException {
+        String username = null;
+        var password = "anyPassword";
+        var path = String.format(URI_PATH_FORMAT, URI, "null");
+        var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
+        var response = new HttpResponse(HttpStatus.SC_OK);
+        var expectedBody = objectMapper.writeValueAsString(new UserPasswordDto(password));
+        when(httpClient.post(path, expectedBody)).thenReturn(response);
+
+        var isPasswordValid = restUserService.isPasswordValid(username, password);
+
+        assertTrue(isPasswordValid);
+    }
+
+    @Test
     void isPasswordValidShouldReturnTrueWhenPasswordsMatchesAndUsernameContainsSpace() throws IOException {
         var username = "some Username";
         var password = "anyPassword";

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -329,7 +329,7 @@ class RestUserServiceTest {
     void isPasswordValidShouldNotThrowNullPointerExceptionWhenPasswordIsNull() throws IOException {
         String username = null;
         var password = "anyPassword";
-        var path = String.format(URI_PATH_FORMAT, URI, "null");
+        var path = String.format(URI_PATH_FORMAT, URI, username);
         var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
         var response = new HttpResponse(HttpStatus.SC_OK);
         var expectedBody = objectMapper.writeValueAsString(new UserPasswordDto(password));


### PR DESCRIPTION
Usernames are now url encoded, otherwise the plugin throws an exception when the username contains space:
```
Caused by: java.lang.IllegalArgumentException: Illegal character in path at index 66: http://shoreline.tidepool-prod.svc.cluster.local:9107/migrate/todd ka           │
│     at java.base/java.net.URI.create(URI.java:883)                                                                                                                    │
│     at org.apache.http.client.methods.HttpGet.<init>(HttpGet.java:66)                                                                                                 │
│     at com.danielfrak.code.keycloak.providers.rest.rest.http.HttpClient.get(HttpClient.java:56)                                                                       │
│     at com.danielfrak.code.keycloak.providers.rest.rest.RestUserService.findLegacyUser(RestUserService.java:73)                                                       │
│     ... 74 more
```
