### PR TITLE
feat: add federated identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ The GET request will have to return user data as a JSON response in the form:
   ],
   "requiredActions": [
     "requiredActions"
+  ],
+  "legacyFederatedIdentities": [
+    {
+      "identityProvider": "string",
+      "userId": "string",
+      "userName": "string",
+      "token": "string"
+    }
   ]
 }
 ```
@@ -139,6 +147,14 @@ response might look like this:
     "UPDATE_PASSWORD",
     "UPDATE_PROFILE",
     "update_user_locale"
+  ],
+  "legacyFederatedIdentities": [
+    {
+      "identityProvider": "google",
+      "userId": "105503037730434619227",
+      "userName": "bob",
+      "token": ""
+    }
   ]
 }
 ```

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyFederatedIdentity.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyFederatedIdentity.java
@@ -1,0 +1,69 @@
+package com.danielfrak.code.keycloak.providers.rest.remote;
+
+import java.util.Objects;
+
+public class LegacyFederatedIdentity {
+
+    private String identityProvider;
+    private String userId;
+    private String userName;
+    private String token;
+
+    public String getIdentityProvider() {
+        return identityProvider;
+    }
+
+    public void setIdentityProvider(String identityProvider) {
+        this.identityProvider = identityProvider;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LegacyFederatedIdentity legacyFederatedIdentity = (LegacyFederatedIdentity) o;
+
+        return Objects.equals(identityProvider, legacyFederatedIdentity.identityProvider)
+                && Objects.equals(userId, legacyFederatedIdentity.userId)
+                && Objects.equals(userName, legacyFederatedIdentity.userName)
+                && Objects.equals(token, legacyFederatedIdentity.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                identityProvider,
+                userId,
+                userName,
+                token
+        );
+    }
+}

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
@@ -20,6 +20,7 @@ public class LegacyUser {
     private List<String> roles;
     private List<String> groups;
     private List<String> requiredActions;
+    private List<LegacyFederatedIdentity> legacyFederatedIdentities;
 
     public String getId() {
         return id;
@@ -109,6 +110,14 @@ public class LegacyUser {
         this.requiredActions = requiredActions;
     }
 
+    public List<LegacyFederatedIdentity> getLegacyFederatedIdentities() {
+        return legacyFederatedIdentities;
+    }
+
+    public void setLegacyFederatedIdentities(List<LegacyFederatedIdentity> legacyFederatedIdentities) {
+        this.legacyFederatedIdentities = legacyFederatedIdentities;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -129,12 +138,13 @@ public class LegacyUser {
                 Objects.equals(attributes, legacyUser.attributes) &&
                 Objects.equals(roles, legacyUser.roles) &&
                 Objects.equals(groups, legacyUser.groups) &&
-                Objects.equals(requiredActions, legacyUser.requiredActions);
+                Objects.equals(requiredActions, legacyUser.requiredActions) &&
+                Objects.equals(legacyFederatedIdentities, legacyUser.legacyFederatedIdentities);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, username, email, firstName, lastName, isEnabled, isEmailVerified, attributes,
-                roles, groups, requiredActions);
+                roles, groups, requiredActions, legacyFederatedIdentities);
     }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
@@ -93,6 +93,17 @@ public class UserModelFactory {
                 .forEach(userModel::addRequiredAction);
         }
 
+        if (legacyUser.getLegacyFederatedIdentities() != null) {
+            legacyUser.getLegacyFederatedIdentities()
+                .forEach(x ->
+                    session.users().addFederatedIdentity(
+                        realm,
+                        userModel,
+                        this.createFederatedIdentityModel(x)
+                    )
+                );
+        }
+
         return userModel;
     }
 
@@ -102,6 +113,15 @@ public class UserModelFactory {
         }
 
         return session.users().getUserById(realm, legacyUser.getId()) != null;
+    }
+
+    private FederatedIdentityModel createFederatedIdentityModel(LegacyFederatedIdentity fi) {
+        return new FederatedIdentityModel(
+            fi.getIdentityProvider(),
+            fi.getUserId(),
+            fi.getUserName(),
+            fi.getToken()
+        );
     }
 
     private void validateUsernamesEqual(LegacyUser legacyUser, UserModel userModel) {


### PR DESCRIPTION
The Google Identity provider is not supported, but the user is successfully migrated when the Google user sign-in plugin is available. But there is a problem with the web page the user is facing. The web page shows two options (edit profile and add existing account). Because there is a user from the legacy system, this option appears.

The purpose of this pull request is to solve this web page issue. The user should be redirected to the home page.

But... this doesn't quite solve the problem. This PR prevents the mentioned options from appearing if the user tries again log in with google (second time).

First time:
<img width="918" alt="Screenshot 2023-06-14 at 4 14 09 PM" src="https://github.com/daniel-frak/keycloak-user-migration/assets/15075759/d9751ed7-2c53-453c-8d54-115bfc6392a8">

But as I said, for the second time, that page doesn't show up (which is the goal of this PR). 

Issue #37 discusses this PR