### PR TITLE
Refactor RestUserService methods to handle exceptions

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 import org.keycloak.common.util.Encode;
 import org.keycloak.component.ComponentModel;
+import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import static com.danielfrak.code.keycloak.providers.rest.ConfigurationProperties.*;
 
 public class RestUserService implements LegacyUserService {
+    private static final Logger Log = Logger.getLogger(RestUserService.class);
 
     private final String uri;
     private final HttpClient httpClient;
@@ -81,7 +83,9 @@ public class RestUserService implements LegacyUserService {
             var legacyUser = objectMapper.readValue(response.getBody(), LegacyUser.class);
             return Optional.ofNullable(legacyUser);
         } catch (RuntimeException|IOException e) {
-            throw new RestUserProviderException(e);
+            Log.errorf("Got a RuntimeException or IOException: when looking up user %s", usernameOrEmail);
+            Log.errorf("Exception message: %s", e.getMessage());
+            return Optional.empty();
         }
     }
 
@@ -97,7 +101,9 @@ public class RestUserService implements LegacyUserService {
             var response = httpClient.post(passwordValidationUri, json);
             return response.getCode() == HttpStatus.SC_OK;
         } catch (IOException e) {
-            throw new RestUserProviderException(e);
+            Log.errorf("Got an IOException: when validating password for user %s", username);
+            Log.errorf("Exception message: %s", e.getMessage());
+            return false;
         }
     }
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -2,7 +2,6 @@ package com.danielfrak.code.keycloak.providers.rest.rest;
 
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUserService;
-import com.danielfrak.code.keycloak.providers.rest.exceptions.RestUserProviderException;
 import com.danielfrak.code.keycloak.providers.rest.rest.http.HttpClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -93,31 +93,28 @@ class RestUserServiceTest {
     }
 
     @Test
-    void findByEmailShouldThrowWhenRuntimeExceptionOccurs() {
+    void findByEmailShouldReturnEmptyWhenRuntimeExceptionOccurs() {
         var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
         var cause = new RuntimeException();
 
         when(httpClient.get(any()))
                 .thenThrow(cause);
 
-        var exception = assertThrows(RestUserProviderException.class,
-                () -> restUserService.findByEmail("someEmail"));
+        var result = restUserService.findByEmail("someEmail");
 
-        assertThat(exception.getCause()).isEqualTo(cause);
+        assertThat(result).isEmpty();
     }
 
     @Test
-    void findByEmailShouldThrowWhenIOExceptionOccurs() {
+    void findByEmailShouldReturnEmptyWhenIOExceptionOccurs() {
         var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
 
         when(httpClient.get(any()))
                 .thenReturn(new HttpResponse(200, "malformedJson"));
 
-        var exception = assertThrows(RestUserProviderException.class,
-                () -> restUserService.findByEmail("someEmail"));
+        var result = restUserService.findByEmail("someEmail");
 
-        assertThat(exception.getCause().getClass())
-                .isSameAs(JsonParseException.class);
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -201,28 +198,28 @@ class RestUserServiceTest {
     }
 
     @Test
-    void findByUsernameShouldThrowWhenRuntimeExceptionOccurs() {
+    void findByUsernameShouldReturnEmptyWhenRuntimeExceptionOccurs() {
         var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
         var cause = new RuntimeException();
 
         when(httpClient.get(any()))
                 .thenThrow(cause);
 
-        assertThatThrownBy(() -> restUserService.findByUsername("someUsername"))
-                .isInstanceOf(RestUserProviderException.class)
-                .hasCause(cause);
+        var result = restUserService.findByUsername("someUsername");
+
+        assertThat(result).isEmpty();
     }
 
     @Test
-    void findByUsernameShouldThrowWhenIOExceptionOccurs() {
+    void findByUsernameShouldReturnEmptyWhenIOExceptionOccurs() {
         var restUserService = new RestUserService(model, httpClient, new ObjectMapper());
 
         when(httpClient.get(any()))
                 .thenReturn(new HttpResponse(200, "malformedJson"));
 
-        assertThatThrownBy(() -> restUserService.findByUsername("someUsername"))
-                .isInstanceOf(RestUserProviderException.class)
-                .hasCauseInstanceOf(JsonParseException.class);
+        var result = restUserService.findByUsername("someUsername");
+
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -371,7 +368,7 @@ class RestUserServiceTest {
     }
 
     @Test
-    void isPasswordValidShouldThrowWhenIOExceptionOccurs() throws JsonProcessingException {
+    void isPasswordValidShouldReturnFalseWhenIOExceptionOccurs() throws JsonProcessingException {
         var mockObjectMapper = mock(ObjectMapper.class);
         var cause = mock(JsonProcessingException.class);
         var restUserService = new RestUserService(model, httpClient, mockObjectMapper);
@@ -379,9 +376,8 @@ class RestUserServiceTest {
         when(mockObjectMapper.writeValueAsString(any()))
                 .thenThrow(cause);
 
-        assertThatThrownBy(() -> restUserService.isPasswordValid(
-                "someUsername", "somePassword"))
-                .isInstanceOf(RestUserProviderException.class)
-                .hasCause(cause);
+        var isPasswordValid = restUserService.isPasswordValid(
+                "someUsername", "somePassword");
+        assertThat(isPasswordValid).isFalse();
     }
 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -1,6 +1,5 @@
 package com.danielfrak.code.keycloak.providers.rest.rest;
 
-import com.danielfrak.code.keycloak.providers.rest.exceptions.RestUserProviderException;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyTotp;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
 import com.danielfrak.code.keycloak.providers.rest.rest.http.HttpClient;


### PR DESCRIPTION
This pull request refactors the RestUserService methods `findLegacyUser` and `isPasswordValid` to handle exceptions. Previously, these methods would throw a `RestUserProviderException` when a `RuntimeException` or `IOException` occurred. Now, instead of throwing an exception, the methods log the error message and return an empty optional or `false` respectively.