### PR TITLE
Add setting for Client ID, and for using only roles on Client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ legacy system for illustration purposes only.
 
 Additional configuration options are available for fine-tuning the migration.
 
+### Valid for Client ID
+
+Enter the Client ID that the migration should be valid for, or leave empty if valid for all clients.  
+The user federations are called in the defined order each time a user is not found in Keycloak, until one of
+them says that they have found the user. When migrating users from multiple legacy systems, where a user can exist
+in more than one, the credentials may then be validated against a different legacy system than the user was logging into.  
+This can also be used if only users that log in from a specific client should be migrated, preventing unnecessary
+requests to the legacy system for other clients.  
+
 ### Bearer Token Auth
 
 ![Bearer Token Auth](readme-images/config_bearer_token.png)
@@ -311,7 +320,14 @@ automatically map legacy roles to Keycloak roles, by specifying the mapping in t
 This switch can be toggled to decide whether roles which are not defined in the legacy role conversion map should be
 migrated anyway or simply ignored.
 
-### Group role conversion
+### Restrict to client roles
+
+If enabled, and 'Valid for Client ID' is set, only roles defined on that client will be used. If migration
+can create roles, they will be created on the client.  
+If disabled, or 'Valid for Client ID' is not set, roles in realm and all clients are used. If migration 
+can create roles, they will be created in the realm.
+
+### Legacy group conversion
 
 If group names in Keycloak do not perfectly match those in the legacy system, you can configure the provider to
 automatically map legacy groups to Keycloak groups, by specifying the mapping in the format `legacyGroup:keycloakGroup`.

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/ConfigurationProperties.java
@@ -20,12 +20,24 @@ public final class ConfigurationProperties {
     public static final String GROUP_MAP_PROPERTY = "GROUP_MAP";
     public static final String MIGRATE_UNMAPPED_ROLES_PROPERTY = "MIGRATE_UNMAPPED_ROLES";
     public static final String MIGRATE_UNMAPPED_GROUPS_PROPERTY = "MIGRATE_UNMAPPED_GROUPS";
+    public static final String VALID_FOR_CLIENT_PROPERTY = "VALID_FOR_CLIENT";
+    public static final String RESTRICT_ROLES_TO_CLIENT = "RESTRICT_ROLES_TO_CLIENT";
 
     private static final List<ProviderConfigProperty> PROPERTIES = List.of(
             new ProviderConfigProperty(URI_PROPERTY,
                     "Rest client URI (required)",
                     "URI of the legacy system endpoints",
                     STRING_TYPE, null),
+            new ProviderConfigProperty(VALID_FOR_CLIENT_PROPERTY,
+                    "Valid for Client ID",
+                    """
+                            The migration can be restricted to only migrate users logging in \
+                            using a specific client. Only roles defined on the client will be used. \
+                            New roles will be created on the client instead of in Realm Roles.
+                            Enter a Client ID, or leave blank if valid for all clients.
+                            """,
+                    STRING_TYPE,
+                    null),
             new ProviderConfigProperty(API_TOKEN_ENABLED_PROPERTY,
                     "Rest client Bearer token auth enabled",
                     "Enables Bearer token authentication for legacy user service",
@@ -48,7 +60,7 @@ public final class ConfigurationProperties {
                     PASSWORD, null),
             new ProviderConfigProperty(USE_USER_ID_FOR_CREDENTIAL_VERIFICATION,
                     "Use user id for credential verification",
-                    "Use the id of the user instead of the username as the path" +
+                    "Use the id of the user instead of the username as the path " +
                     "parameter when making a credential verification request",
                     BOOLEAN_TYPE, false),
             new ProviderConfigProperty(ROLE_MAP_PROPERTY,
@@ -59,6 +71,14 @@ public final class ConfigurationProperties {
                     "Migrate unmapped roles",
                     "Whether or not to migrate roles not found in the field above",
                     BOOLEAN_TYPE, true),
+            new ProviderConfigProperty(RESTRICT_ROLES_TO_CLIENT,
+                    "Restrict role actions to client",
+                    """
+                        If 'Valid Client ID' is set, this will restrict the use roles to those \
+                        defined on that client.
+                        New roles will be created on the client instead of in the realm.
+                    """,
+                    BOOLEAN_TYPE, false),
             new ProviderConfigProperty(GROUP_MAP_PROPERTY,
                     "Legacy group conversion",
                     "Group conversion in the format 'legacyGroup:newGroup'",

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -152,6 +152,13 @@ public class LegacyProvider implements UserStorageProvider,
     }
 
     private UserModel getUserModel(RealmModel realm, String username, Supplier<Optional<LegacyUser>> user) {
+        String restrictedClient = model.getConfig().getFirst(ConfigurationProperties.VALID_FOR_CLIENT_PROPERTY);
+        String sessionClient = this.session.getContext().getClient().getClientId();
+
+        if (restrictedClient != null && !restrictedClient.equals(sessionClient)) {
+            return null;
+        }
+
         return user.get()
                 .filter(u -> {
                     // Make sure we're not trying to migrate users if they have changed their username


### PR DESCRIPTION
Adds two settings:
- **Valid for Client ID**: The migration is only valid for this Client ID
- **Restrict role actions to client**: Role actions will only be performed on client defined by Client ID

Updated README