### PR TITLE
Added Organization Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ The GET request will have to return user data as a JSON response in the form:
       "algorithm": "string",
       "encoding": "string"
     }
+  ],
+  "organizations": [
+     {
+        "orgName": "org-1",
+        "orgAlias": "org-1"
+     }
   ]
 }
 ```
@@ -167,7 +173,13 @@ response might look like this:
       "algorithm": "HmacSHA1",
       "encoding": "BASE32"
     }
-  ]
+  ],
+  "organizations": [
+    {
+      "orgName": "org-1",
+      "orgAlias": "org-1"
+    }
+   ]
 }
 ```
 
@@ -340,3 +352,14 @@ This module supports the migration of totp devices. The totp configuration block
 UTF-8 plaintext.
 For the utf8 bytes just set the `encoding` attribute to null.
 Possible `algorithm`s are: HmacSHA1, HmacSHA256, HmacSHA512
+
+## Organizations
+
+This module provides support for organizations. The organization feature is available in Keycloak 26 and above. However, it must be explicitly enabled in the realm settings to use this functionality.
+To configure organizations, you can use the following JSON block as an example
+```json
+[
+   {"orgName":  "org-1", "orgAlias":  "org-1"}
+]
+```
+If organization does not exist inside KeyCloak, This extension will create the organization first then it will assign the user.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.danielfrak.code.keycloak.providers</groupId>
     <artifactId>keycloak-rest-provider</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.0.4-SNAPSHOT</version>
     <properties>
         <java.version>21</java.version>
         <keycloak.version>26.0.5</keycloak.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.danielfrak.code.keycloak.providers</groupId>
     <artifactId>keycloak-rest-provider</artifactId>
-    <version>6.0.4-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <properties>
         <java.version>21</java.version>
         <keycloak.version>26.0.5</keycloak.version>

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyOrganization.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyOrganization.java
@@ -1,0 +1,8 @@
+package com.danielfrak.code.keycloak.providers.rest.remote;
+
+public record LegacyOrganization(
+        String orgName,
+        String orgAlias)
+{
+
+}

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUser.java
@@ -20,6 +20,7 @@ public record LegacyUser(
         List<String> roles,
         List<String> groups,
         List<String> requiredActions,
-        List<LegacyTotp> totps
+        List<LegacyTotp> totps,
+        List<LegacyOrganization> organizations
 ) {
 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserTest.java
@@ -36,7 +36,8 @@ class LegacyUserTest {
                 List.of("group1"),
                 List.of("requiredAction1"),
                 List.of(new LegacyTotp("secret", "name", 1, 2, "someAlgorithm",
-                        "someEncoding"))
+                        "someEncoding")),
+                List.of(new LegacyOrganization("org-1", "org-1"))
         );
     }
 
@@ -72,6 +73,12 @@ class LegacyUserTest {
                       "period": 2,
                       "algorithm": "someAlgorithm",
                       "encoding": "someEncoding"
+                    }
+                  ],
+                  "organizations": [
+                    {
+                      "orgName": "org-1",
+                      "orgAlias": "org-1"
                     }
                   ]
                 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/TestLegacyUser.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/TestLegacyUser.java
@@ -22,6 +22,7 @@ public class TestLegacyUser {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
@@ -36,6 +37,7 @@ public class TestLegacyUser {
                 true,
                 true,
                 emptyMap(),
+                emptyList(),
                 emptyList(),
                 emptyList(),
                 emptyList(),
@@ -56,6 +58,7 @@ public class TestLegacyUser {
                 emptyList(),
                 emptyList(),
                 emptyList(),
+                emptyList(),
                 emptyList()
         );
     }
@@ -71,6 +74,7 @@ public class TestLegacyUser {
                 true,
                 emptyMap(),
                 Arrays.asList(null, ""),
+                emptyList(),
                 emptyList(),
                 emptyList(),
                 emptyList()
@@ -90,6 +94,7 @@ public class TestLegacyUser {
                 List.of("oldRole", "anotherRole"),
                 emptyList(),
                 emptyList(),
+                emptyList(),
                 emptyList()
         );
     }
@@ -106,6 +111,7 @@ public class TestLegacyUser {
                 emptyMap(),
                 emptyList(),
                 List.of("oldGroup", "anotherGroup"),
+                emptyList(),
                 emptyList(),
                 emptyList()
         );
@@ -124,6 +130,7 @@ public class TestLegacyUser {
                 emptyList(),
                 Arrays.asList(null, ""),
                 emptyList(),
+                emptyList(),
                 emptyList()
         );
     }
@@ -141,6 +148,7 @@ public class TestLegacyUser {
                 emptyList(),
                 emptyList(),
                 List.of("CONFIGURE_TOTP", "UPDATE_PASSWORD"),
+                emptyList(),
                 emptyList()
         );
     }
@@ -161,11 +169,32 @@ public class TestLegacyUser {
                 List.of(
                         legacyTotp("Device 1", "SECRET_1"),
                         legacyTotp("Device 2", "SECRET_2")
-                )
+                ),
+                emptyList()
+        );
+    }
+
+    public static LegacyUser aLegacyUserWithOneOrg() {
+        return new LegacyUser(
+                null,
+                "someUserName",
+                "user@email.com",
+                "John",
+                "Smith",
+                true,
+                true,
+                emptyMap(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                List.of(new LegacyOrganization("org-1", "org-1"))
         );
     }
 
     private static LegacyTotp legacyTotp(String name, String secret) {
         return new LegacyTotp(secret, name, 0, 0, null, null);
     }
+
+
 }

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.danielfrak.code.keycloak.providers.rest.rest;
 
+import com.danielfrak.code.keycloak.providers.rest.remote.LegacyOrganization;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyTotp;
 import com.danielfrak.code.keycloak.providers.rest.remote.LegacyUser;
 import com.danielfrak.code.keycloak.providers.rest.rest.http.HttpClient;
@@ -145,7 +146,8 @@ class RestUserServiceTest {
                 List.of("migrated_users"),
                 List.of("CONFIGURE_TOTP"),
                 List.of(new LegacyTotp("someSecret", "someName", 1, 2,
-                        "someAlgorithm", "someEncoding"))
+                        "someAlgorithm", "someEncoding")),
+                List.of(new LegacyOrganization("org-1", "org-1"))
         );
     }
 


### PR DESCRIPTION
**Summary**
This PR adds support for organizations during user migration. Organizations will only be added if the organization feature is enabled at the realm level.

**Details**
Using the following organization payload, this extension will create organizations within the realm and assign the specified user to the corresponding organization:

```json
[
   {
      "orgName": "org-1",
      "orgAlias": "org-1"
   }
]
```

**Implementation**
- The extension checks if the organization feature is enabled.
- If the specified organization does not exist, it will be created.
- The user will be assigned to the newly created or existing organization.