### PR TITLE
fix(provider): return true from isConfiguredFor for supported credential types

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -54,7 +54,7 @@ public class LegacyProvider implements UserStorageProvider,
 
     @Override
     public boolean isConfiguredFor(RealmModel realmModel, UserModel userModel, String s) {
-        return false;
+        return supportsCredentialType(s);
     }
 
     @Override

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -635,9 +635,15 @@ class LegacyProviderTest {
     }
 
     @Test
-    void isConfiguredForShouldAlwaysReturnFalse() {
+    void isConfiguredForShouldReturnTrueForSupportedCredentialType() {
+        assertTrue(legacyProvider.isConfiguredFor(mock(RealmModel.class), mock(UserModel.class),
+                PasswordCredentialModel.TYPE));
+    }
+
+    @Test
+    void isConfiguredForShouldReturnFalseForUnsupportedCredentialType() {
         assertFalse(legacyProvider.isConfiguredFor(mock(RealmModel.class), mock(UserModel.class),
-                "someString"));
+                "someUnsupportedType"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Make `LegacyProvider.isConfiguredFor(...)` return `true` for credential types the plugin already supports (currently password), instead of unconditionally returning `false`. This aligns the provider's reported contract with what `isValid(...)` actually does.

Without this change, realms whose browser flow splits the username and password steps (`Username Form` + `Password Form` instead of the combined `Username Password Form`) abort with `CREDENTIAL_SETUP_REQUIRED` before `isValid(...)` is ever called, so passwords are never sent to the configured REST endpoint and legacy users can no longer be migrated.

## Related Issues

Closes #443

## Testing

- Replaced the existing `isConfiguredForShouldAlwaysReturnFalse` test with two new cases:
  - `isConfiguredForShouldReturnTrueForSupportedCredentialType` asserts `true` for `PasswordCredentialModel.TYPE`.
  - `isConfiguredForShouldReturnFalseForUnsupportedCredentialType` asserts `false` for an arbitrary unsupported type string.
- `./mvnw -Dtest=LegacyProviderTest test` passes locally: 41/41 green.
