### PR TITLE
fix: Ignore case when comparing usernames

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LocalUserLookup.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LocalUserLookup.java
@@ -59,7 +59,7 @@ public class LocalUserLookup {
         }
 
         return Optional.ofNullable(userProvider.getUserById(realm, legacyId))
-                .filter(user -> legacyUser.username().equals(user.getUsername()))
+                .filter(user -> legacyUser.username().equalsIgnoreCase(user.getUsername()))
                 .map(user -> {
                     LOG.debugf("Located existing user %s by legacy id %s.", legacyUser.username(), legacyId);
                     return user;

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactory.java
@@ -78,7 +78,7 @@ public class UserModelFactory {
     }
 
     private void validateUsernamesEqual(LegacyUser legacyUser, UserModel userModel) {
-        if (!userModel.getUsername().equals(legacyUser.username())) {
+        if (!userModel.getUsername().equalsIgnoreCase(legacyUser.username())) {
             throw new IllegalStateException(String.format("Local and remote users differ: [%s != %s]",
                     userModel.getUsername(),
                     legacyUser.username()));

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -156,6 +156,26 @@ class LegacyProviderTest {
     }
 
     @Test
+    void shouldUpdateExistingUserDataWhenFoundByLegacyIdWithUsernameDifferingOnlyInCase() {
+        final String username = "user";
+        final LegacyUser legacyUser = withId();
+        when(legacyUserService.findByUsername(username))
+                .thenReturn(Optional.of(legacyUser));
+        when(userProvider.getUserByUsername(realmModel, legacyUser.username()))
+                .thenReturn(null);
+        when(userProvider.getUserById(realmModel, legacyUser.id()))
+                .thenReturn(userModel);
+        when(userModel.getUsername())
+                .thenReturn(legacyUser.username().toLowerCase());
+
+        var result = legacyProvider.getUserByUsername(realmModel, username);
+
+        assertEquals(userModel, result);
+        verify(userModelFactory).updateUserAttributes(legacyUser, userModel);
+        verify(userModelFactory, never()).create(any(), any());
+    }
+
+    @Test
     void shouldCreateUserWhenLegacyIdIsBlankAndNoLocalUserExists() {
         final String username = "user";
         final LegacyUser user = new LegacyUser(

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactoryTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactoryTest.java
@@ -169,6 +169,18 @@ class UserModelFactoryTest {
         }
 
         @Test
+        void shouldNotThrowWhenKeycloakLowercasesTheUsername() {
+            final LegacyUser legacyUser = TestLegacyUser.minimal();
+            when(userProvider.addUser(realm, legacyUser.username()))
+                    .thenReturn(new TestUserModel(legacyUser.username().toLowerCase()));
+            userModelFactory = constructUserModelFactory();
+
+            UserModel result = userModelFactory.create(legacyUser, realm);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
         void shouldMigrateBasicAttributes() {
             final LegacyUser legacyUser = TestLegacyUser.minimal();
             mockSuccessfulUserModelCreationWithoutIdMigration(legacyUser);


### PR DESCRIPTION
Fixes #138:
- `IllegalStateException` was thrown on first login for any mixed-case username
- lookup-by-id matches a case-only-different username

Keycloak JPA stores the username as lowercase:

https://github.com/keycloak/keycloak/blob/b946503888843eb8b6a63277746676cf71e0d3dd/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java#L133
```java
        entity.setUsername(username.toLowerCase());
```