### PR TITLE
feat: Update username if legacy id is provided

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LocalUserLookup.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LocalUserLookup.java
@@ -31,7 +31,7 @@ public class LocalUserLookup {
             UserProvider userProvider = session.users();
 
             return getUserByUsername(realm, legacyUser, userProvider)
-                    .or(() -> findByIdAndUsername(realm, legacyUser, userProvider))
+                    .or(() -> findById(realm, legacyUser, userProvider))
                     .or(() -> {
                         LOG.debugf("No existing user %s located in local storage.", legacyUser.username());
                         return Optional.empty();
@@ -50,8 +50,8 @@ public class LocalUserLookup {
         return Optional.ofNullable(userModel);
     }
 
-    private Optional<UserModel> findByIdAndUsername(RealmModel realm, LegacyUser legacyUser,
-                                                    UserProvider userProvider) {
+    private Optional<UserModel> findById(RealmModel realm, LegacyUser legacyUser,
+                                         UserProvider userProvider) {
         String legacyId = legacyUser.id();
         if (legacyId == null || legacyId.isBlank()) {
             LOG.debugf("Legacy user %s does not expose an id. Skipping lookup by id.", legacyUser.username());
@@ -59,9 +59,8 @@ public class LocalUserLookup {
         }
 
         return Optional.ofNullable(userProvider.getUserById(realm, legacyId))
-                .filter(user -> legacyUser.username().equals(user.getUsername()))
                 .map(user -> {
-                    LOG.debugf("Located existing user %s by legacy id %s.", legacyUser.username(), legacyId);
+                    LOG.debugf("Located existing user by legacy id %s.", legacyId);
                     return user;
                 });
     }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactory.java
@@ -86,6 +86,7 @@ public class UserModelFactory {
     }
 
     public void updateUserAttributes(LegacyUser legacyUser, UserModel userModel) {
+        userModel.setUsername(legacyUser.username());
         userModel.setEnabled(legacyUser.isEnabled());
         userModel.setEmail(legacyUser.email());
         userModel.setEmailVerified(legacyUser.isEmailVerified());

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -218,7 +218,7 @@ class LegacyProviderTest {
     }
 
     @Test
-    void shouldReturnNullIfUserIdExistsButHasDifferentUsername() {
+    void shouldReturnExistingUserAndUpdateAttributesWhenUserIdExistsButHasDifferentUsername() {
         final String email = "email";
         final LegacyUser user = withId();
         when(legacyUserService.findByEmail(email))
@@ -230,12 +230,11 @@ class LegacyProviderTest {
                 .thenReturn("different");
         when(userProvider.getUserById(realmModel, user.id()))
                 .thenReturn(existingUser);
-        when(userModelFactory.isDuplicateUserId(user, realmModel))
-                .thenReturn(true);
 
         var result = legacyProvider.getUserByEmail(realmModel, email);
 
-        assertNull(result);
+        assertNotNull(result);
+        verify(userModelFactory).updateUserAttributes(user, existingUser);
         verify(userModelFactory, never()).create(any(), any());
     }
 

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactoryTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/remote/usermodel/UserModelFactoryTest.java
@@ -1243,6 +1243,30 @@ class UserModelFactoryTest {
     class UpdateUserAttributes {
 
         @Test
+        void shouldUpdateUsernameOnExistingUser() {
+            var legacyUser = new LegacyUser(
+                    null,
+                    "newUsername",
+                    "email@example.com",
+                    "First",
+                    "Last",
+                    true, true,
+                    Map.of(),
+                    emptyList(),
+                    emptyList(),
+                    emptyList(),
+                    emptyList(),
+                    emptyList()
+            );
+            UserModel userModel = new TestUserModel("oldUsername");
+
+            userModelFactory = constructUserModelFactory();
+            userModelFactory.updateUserAttributes(legacyUser, userModel);
+
+            assertThat(userModel.getUsername()).isEqualTo("newUsername");
+        }
+
+        @Test
         void shouldUpdateBasicAttributesOnExistingUser() {
             var legacyUser = new LegacyUser(
                     null,


### PR DESCRIPTION
- **Before:** If a user changed their username on the legacy system, they could not be matched in keycloak (neither by username nor by id)
- **After:** Users are matched by legacy id regardless of username. When matched, the username is updated in Keyclaok to match the legacy system value.

This would fix #465